### PR TITLE
Update amounts in app.js

### DIFF
--- a/project-6/src/js/app.js
+++ b/project-6/src/js/app.js
@@ -218,7 +218,7 @@ App = {
         var processId = parseInt($(event.target).data('id'));
 
         App.contracts.SupplyChain.deployed().then(function(instance) {
-            const productPrice = web3.toWei(1, "ether");
+            const productPrice = web3.toWei(1000000, "gwei");
             console.log('productPrice',productPrice);
             return instance.sellItem(App.upc, App.productPrice, {from: App.metamaskAccountID});
         }).then(function(result) {
@@ -234,7 +234,7 @@ App = {
         var processId = parseInt($(event.target).data('id'));
 
         App.contracts.SupplyChain.deployed().then(function(instance) {
-            const walletValue = web3.toWei(3, "ether");
+            const walletValue = web3.toWei(2000000, "gwei");
             return instance.buyItem(App.upc, {from: App.metamaskAccountID, value: walletValue});
         }).then(function(result) {
             $("#ftc-item").text(result);


### PR DESCRIPTION
Some testnet faucets only issue a fraction of an ether. Reducing the price ensures that the transaction will still push through just in case it was done on the test network (although this is not required in the project). The "gwei" unit was used for backwards compatibility just in case an older version of web3 was used.